### PR TITLE
Jellyfin观看记录同步Bangumi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 *.log
 *.db
+
+/crates/bangumi007/data
+/crates/bangumi007/log

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 
 /log
+/data
 /data/database
 /data/config
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "09f46c18d99ba61ad7123dd13eeb0c104436ab6af1df6a1cd8c11054ed394a08"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "async-channel",
+ "async-channel 2.3.1",
  "async-once-cell",
  "atspi",
  "futures-lite 1.13.0",
@@ -246,11 +246,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
 dependencies = [
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
  "event-listener 2.5.3",
  "futures-core",
 ]
@@ -290,6 +311,21 @@ dependencies = [
  "autocfg",
  "blocking",
  "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io 2.3.2",
+ "async-lock 3.3.0",
+ "blocking",
+ "futures-lite 2.3.0",
+ "once_cell",
 ]
 
 [[package]]
@@ -404,6 +440,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +515,21 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -511,12 +611,14 @@ dependencies = [
 name = "bangumi007"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "chrono",
  "colored",
  "config",
  "eframe",
  "egui_extras",
  "fancy-regex 0.13.0",
+ "futures",
  "html-escape",
  "image",
  "lazy_static",
@@ -527,6 +629,7 @@ dependencies = [
  "regex",
  "reqwest",
  "retry",
+ "rocket",
  "roxmltree 0.20.0",
  "rusqlite",
  "serde",
@@ -548,6 +651,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "binascii"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bincode"
@@ -656,7 +765,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel",
+ "async-channel 2.3.1",
  "async-task",
  "futures-io",
  "futures-lite 2.3.0",
@@ -1004,6 +1113,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1302,39 @@ name = "destructure_traitobject"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
+
+[[package]]
+name = "devise"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6eacefd3f541c66fc61433d65e54e0e46e0a029a819a7dbbc7a7b489e8a85f8"
+dependencies = [
+ "devise_codegen",
+ "devise_core",
+]
+
+[[package]]
+name = "devise_codegen"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8cf4b8dd484ede80fd5c547592c46c3745a617c8af278e2b72bea86b2dfed6"
+dependencies = [
+ "devise_core",
+ "quote",
+]
+
+[[package]]
+name = "devise_core"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b50dba0afdca80b187392b24f2499a88c336d5a8493e4b4ccfb608708be56a"
+dependencies = [
+ "bitflags 2.5.0",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "digest"
@@ -1681,8 +1834,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1707,6 +1860,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic 0.6.0",
+ "pear",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
 ]
 
 [[package]]
@@ -1793,6 +1960,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1989,17 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1843,6 +2036,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,8 +2064,10 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1907,6 +2113,19 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -1978,6 +2197,24 @@ checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2140,6 +2377,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
@@ -2149,7 +2405,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -2251,6 +2507,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -2262,12 +2529,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -2278,8 +2556,8 @@ checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2290,10 +2568,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -2304,9 +2612,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2323,7 +2631,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2340,9 +2648,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -2434,7 +2742,14 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "instant"
@@ -2566,6 +2881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +3000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "serde",
+ "value-bag",
 ]
 
 [[package]]
@@ -2713,6 +3038,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,6 +3065,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2844,6 +3193,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.1.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "tokio",
+ "tokio-util",
+ "version_check",
+]
+
+[[package]]
 name = "naga"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +3306,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -3260,6 +3638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3345,6 +3729,29 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.66",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3573,6 +3980,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3741,6 +4161,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3748,8 +4188,17 @@ checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3760,8 +4209,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3787,11 +4242,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "http-body-util",
- "hyper",
+ "hyper 1.3.1",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3887,6 +4342,87 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rocket"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a516907296a31df7dc04310e7043b61d71954d703b603cc6867a026d7e72d73f"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "atomic 0.5.3",
+ "binascii",
+ "bytes",
+ "either",
+ "figment",
+ "futures",
+ "indexmap",
+ "log",
+ "memchr",
+ "multer",
+ "num_cpus",
+ "parking_lot 0.12.3",
+ "pin-project-lite",
+ "rand",
+ "ref-cast",
+ "rocket_codegen",
+ "rocket_http",
+ "serde",
+ "state",
+ "tempfile",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "ubyte",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "rocket_codegen"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575d32d7ec1a9770108c879fc7c47815a80073f96ca07ff9525a94fcede1dd46"
+dependencies = [
+ "devise",
+ "glob",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "rocket_http",
+ "syn 2.0.66",
+ "unicode-xid",
+ "version_check",
+]
+
+[[package]]
+name = "rocket_http"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e274915a20ee3065f611c044bd63c40757396b6dbc057d6046aec27f14f882b9"
+dependencies = [
+ "cookie",
+ "either",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.29",
+ "indexmap",
+ "log",
+ "memchr",
+ "pear",
+ "percent-encoding",
+ "pin-project-lite",
+ "ref-cast",
+ "serde",
+ "smallvec",
+ "stable-pattern",
+ "state",
+ "time",
+ "tokio",
+ "uncased",
 ]
 
 [[package]]
@@ -4016,6 +4552,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rxml"
@@ -4215,6 +4757,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4376,6 +4927,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable-pattern"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "state"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,7 +5016,7 @@ dependencies = [
  "fnv",
  "once_cell",
  "plist",
- "regex-syntax",
+ "regex-syntax 0.8.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4545,6 +5114,16 @@ checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -4650,8 +5229,21 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.7",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4661,6 +5253,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -4789,6 +5392,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4828,6 +5461,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ubyte"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4842,6 +5484,16 @@ dependencies = [
  "memoffset 0.9.1",
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -5002,6 +5654,18 @@ name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
 
 [[package]]
 name = "vcpkg"
@@ -5837,6 +6501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+dependencies = [
+ "is-terminal",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "log",
  "log4rs",
  "minidom",
+ "rand",
  "regex",
  "reqwest",
  "retry",

--- a/crates/bangumi007/Cargo.toml
+++ b/crates/bangumi007/Cargo.toml
@@ -24,6 +24,7 @@ urlencoding = "2.1.3"
 colored = "2.1.0"
 regex = "1.10.4"
 image = { version = "0.25.1", default-features = false, features = ["png", "jpeg", "webp"] }
+rand = "0.8.5"
 
 [dependencies.egui_extras]
 workspace = true

--- a/crates/bangumi007/Cargo.toml
+++ b/crates/bangumi007/Cargo.toml
@@ -25,6 +25,8 @@ colored = "2.1.0"
 regex = "1.10.4"
 image = { version = "0.25.1", default-features = false, features = ["png", "jpeg", "webp"] }
 rand = "0.8.5"
+rocket = "0.5.1"
+futures = "0.3.30"
 
 [dependencies.egui_extras]
 workspace = true
@@ -41,3 +43,7 @@ features = [
 version = "0.31.0"
 features = ["bundled"]
 
+
+[dependencies.async-std]
+version = "1.6.5"
+features = ["attributes"]

--- a/crates/bangumi007/src/main.rs
+++ b/crates/bangumi007/src/main.rs
@@ -1,7 +1,15 @@
+use std::error::Error;
+
+use rocket::routes;
+
 mod module;
 mod ui;
 
-fn main() {
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // run http_main in a separate thread
+    async_std::task::spawn(module::core::scrobbler_server::http_main());
     // module::core::dev_main::run();
     ui::mainapp::ui_main().unwrap_or(());
+    Ok(())
 }

--- a/crates/bangumi007/src/module/config/config.rs
+++ b/crates/bangumi007/src/module/config/config.rs
@@ -18,6 +18,7 @@ pub struct AppConfig {
     pub log_config: LogConfig,
     pub downloader_config: DownloaderConfig,
     pub parser_config: ParserConfig,
+    pub scrobbler_config: ScrobblerConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -66,6 +67,12 @@ pub struct TMDBConfig {
     pub include_adult: bool,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ScrobblerConfig {
+    pub enabled: bool,
+    pub bangumi_access_token: String,
+}
+
 impl AppConfig {
     fn default() -> Self {
         AppConfig {
@@ -98,6 +105,10 @@ impl AppConfig {
                     include_adult: false,
                 },
             },
+            scrobbler_config: ScrobblerConfig {
+                enabled: false,
+                bangumi_access_token: "FILL_IN_BANGUMI_ACCESS_TOKEN".to_string(),
+            }
         }
     }
 

--- a/crates/bangumi007/src/module/core/mod.rs
+++ b/crates/bangumi007/src/module/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod init;
 pub mod dev_main;
+pub mod scrobbler_server;

--- a/crates/bangumi007/src/module/core/scrobbler_server.rs
+++ b/crates/bangumi007/src/module/core/scrobbler_server.rs
@@ -1,0 +1,133 @@
+use std::fs;
+use async_std::net::TcpListener;
+use async_std::net::TcpStream;
+use futures::stream::StreamExt;
+
+use std::time::Duration;
+use async_std::task;
+use async_std::prelude::*;
+
+use async_std::task::spawn;
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+use crate::module::database::library::find_season_by_disp;
+use crate::module::scrobbler::bangumi::{BangumiEpisodeStatus, update_bangumi_episode_status, update_bangumi_episode_status_send};
+use crate::module::utils::error::new_err;
+use crate::ui::apps::libraryapp;
+use crate::ui::apps::libraryapp::BANGUMI_STATUS_UPDATE;
+
+
+pub(crate) async fn http_main() {
+    let listener = TcpListener::bind("127.0.0.1:8007").await.unwrap();
+    listener
+        .incoming()
+        .for_each_concurrent(/* limit */ None, |stream| async move {
+            let stream = stream.unwrap();
+            spawn(handle_connection(stream));
+        })
+        .await;
+}
+
+async fn handle_connection(mut stream: TcpStream) {
+
+    let mut buffer = [0; 1024];
+    stream.read(&mut buffer).await.unwrap();
+
+    // Parse buffer and decode url parameters
+    // url: /report?series={}&season={}&episode={}&status={}
+    // series: String,
+    // season: i32,
+    // episode: i32,
+    // status: i32,
+    let request = String::from_utf8_lossy(&buffer[..]);
+    let request = request.split_whitespace().collect::<Vec<&str>>();
+    let request = request[1].split("?").collect::<Vec<&str>>();
+    let request = request[1].split("&").collect::<Vec<&str>>();
+    let mut url_params = HashMap::new();
+    for param in request {
+        let param = param.split("=").collect::<Vec<&str>>();
+        url_params.insert(param[0], param[1]);
+    }
+
+    let series = url_params.get("series");
+    let season = url_params.get("season");
+    let episode = url_params.get("episode");
+    let status = url_params.get("status");
+
+    match (series, season, episode, status) {
+        (Some(series), Some(season), Some(episode), Some(status)) => {
+            // continue to update_bangumi_episode_status(series, season, episode, status);
+        },
+        _ => {
+            // return error
+            let response = "HTTP/1.1 400 Bad Request\r\n\r\n";
+            stream.write(response.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+        }
+    }
+
+    let series = series.unwrap();
+    let season = season.unwrap();
+    let episode = episode.unwrap();
+    let status = status.unwrap();
+
+    // url decode
+    let series = urlencoding::decode(series);
+    // parse int
+    let season = season.parse::<i32>();
+    let episode = episode.parse::<i32>();
+    let status = status.parse::<i32>();
+
+    match (&series, &season, &episode, &status) {
+        (Ok(series), Ok(season), Ok(episode), Ok(status)) => {
+            // continue to update_bangumi_episode_status(series, season, episode, status);
+        },
+        _ => {
+            // return error
+            let response = "HTTP/1.1 400 Bad Request\r\n\r\n";
+            stream.write(response.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+        }
+    }
+
+    let series = series.unwrap().to_string();
+    let season = season.unwrap();
+    let episode = episode.unwrap();
+    let status = status.unwrap();
+
+    // Find (disp_series_name, disp_season_num) in database and get bangumi_subject_id, conf_tmdb_episode_offset, conf_bangumi_episode_offset
+    let seasoninfo = find_season_by_disp(series.to_string(), season);
+
+    if let None = seasoninfo {
+        // return error
+        let response = "HTTP/1.1 404 Not Found\r\n\r\n";
+        stream.write(response.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+    }
+    let seasoninfo = seasoninfo.unwrap();
+
+    let bangumi_subject_id = seasoninfo.bangumi_subject_id;
+
+    // Push status to bangumi
+    let result = update_bangumi_episode_status_send(
+        bangumi_subject_id,
+        (episode - seasoninfo.conf_tmdb_episode_offset + seasoninfo.conf_bangumi_episode_offset).to_string(),
+        BangumiEpisodeStatus::Watched,
+    );
+    if !result {
+        // return success
+        let response ="HTTP/1.1 200 OK\r\n\r\n";
+        stream.write(response.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let mut handle = BANGUMI_STATUS_UPDATE.write().unwrap();
+        *handle = true;
+        drop(handle);
+    } else {
+        // return error
+        let response ="HTTP/1.1 500 Internal Server Error\r\n\r\n";
+        stream.write(response.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+    };
+
+}

--- a/crates/bangumi007/src/module/database/cache/rss.rs
+++ b/crates/bangumi007/src/module/database/cache/rss.rs
@@ -23,7 +23,7 @@ pub struct MikanItem {
     pub mikan_parsed_codec: String,
     pub bangumi_parsed_episode_id: i32,
     pub bangumi_parsed_episode_ep: i32,
-    pub bangumi_parsed_episode_sort: i32,
+    pub bangumi_parsed_episode_sort: String,
 }
 
 #[deny(dead_code)]
@@ -46,8 +46,9 @@ pub fn init_cache_mikan_item_table(conn: &Connection) -> Result<(), Box<dyn Erro
             mikan_parsed_codec text,
             bangumi_parsed_episode_id integer,
             bangumi_parsed_episode_ep integer,
-            bangumi_parsed_episode_sort integer
+            bangumi_parsed_episode_sort text
         )",
+        // TODO: bangumi_parsed_episode_id, bangumi_parsed_episode_ep, bangumi_parsed_episode_sort deprecated
         [],
     )?;
     Ok(())
@@ -269,7 +270,7 @@ pub struct BangumiEpisode {
     pub episode_id: i32,
     pub episode_type: i32,
     pub episode_ep: i32,    // raw index of episode
-    pub episode_sort: i32,  // display index of episode
+    pub episode_sort: String,  // display index of episode
     pub episode_name: String,
     pub episode_name_cn: String,
     pub episode_airdate: String,

--- a/crates/bangumi007/src/module/database/library.rs
+++ b/crates/bangumi007/src/module/database/library.rs
@@ -280,6 +280,43 @@ pub fn set_season_disp_season_num(mikan_subject_id: i32, mikan_subgroup_id: i32,
     ).unwrap();
 }
 
+pub fn find_season_by_disp(disp_series_name: String, disp_season_num: i32) -> Option<AnimeSeason> {
+    let conn = get_connection().unwrap();
+    let mut stmt = conn.prepare("select * from library_anime_season where disp_series_name = ?1 and disp_season_num = ?2").unwrap();
+    let season_iter = stmt.query_map(&[&disp_series_name, &disp_season_num.to_string()], |row| {
+        Ok(AnimeSeason {
+            mikan_subject_id: row.get(0)?,
+            mikan_subgroup_id: row.get(1)?,
+            mikan_subject_name: row.get(2)?,
+            mikan_subject_image: row.get(3)?,
+            bangumi_subject_id: row.get(4)?,
+            bangumi_subject_name: row.get(5)?,
+            bangumi_season_num: row.get(6)?,
+            bangumi_subject_image: row.get(7)?,
+            tmdb_series_id: row.get(8)?,
+            tmdb_series_name: row.get(9)?,
+            tmdb_season_num: row.get(10)?,
+            tmdb_season_name: row.get(11)?,
+            bangumi_to_tmdb_episode_offset: row.get(12)?,
+            disp_series_name: row.get(13)?,
+            disp_season_name: row.get(14)?,
+            disp_subgroup_name: row.get(15)?,
+            disp_season_num: row.get(16)?,
+            conf_tmdb_episode_offset: row.get(17)?,
+            conf_language: row.get(18)?,
+            conf_codec: row.get(19)?,
+            conf_season_num: row.get(20)?,
+            conf_bangumi_episode_offset: row.get(21)?,
+        })
+    }).unwrap();
+
+    for season in season_iter {
+        return season.ok();
+    }
+
+    None
+}
+
 
 #[derive(Debug, Clone)]
 pub struct AnimeSeasonItem {

--- a/crates/bangumi007/src/module/database/library.rs
+++ b/crates/bangumi007/src/module/database/library.rs
@@ -23,10 +23,11 @@ pub struct AnimeSeason {
     pub disp_season_name: String,
     pub disp_subgroup_name: String,
     pub disp_season_num: i32,
-    pub conf_episode_offset: i32,
+    pub conf_tmdb_episode_offset: i32,
     pub conf_language: String,
     pub conf_codec: String,
     pub conf_season_num: i32,
+    pub conf_bangumi_episode_offset: i32,
 }
 
 #[deny(dead_code)]
@@ -50,10 +51,11 @@ pub fn init_cache_library_anime_season_table(conn: &Connection) -> Result<(), Bo
             disp_season_name text,
             disp_subgroup_name text,
             disp_season_num integer,
-            conf_episode_offset integer,
+            conf_tmdb_episode_offset integer,
             conf_language text,
             conf_codec text,
             conf_season_num integer default -1,
+            conf_bangumi_episode_offset integer default 0,
             primary key(mikan_subject_id,mikan_subgroup_id) on conflict replace
         )",
         [],
@@ -84,10 +86,11 @@ pub fn read_season_info(mikan_subject_id: i32, mikan_subgroup_id: i32) -> Option
             disp_season_name: row.get(14)?,
             disp_subgroup_name: row.get(15)?,
             disp_season_num: row.get(16)?,
-            conf_episode_offset: row.get(17)?,
+            conf_tmdb_episode_offset: row.get(17)?,
             conf_language: row.get(18)?,
             conf_codec: row.get(19)?,
             conf_season_num: row.get(20)?,
+            conf_bangumi_episode_offset: row.get(21)?,
         })
     }).unwrap();
 
@@ -119,11 +122,12 @@ pub fn create_season(season: &AnimeSeason) {
             disp_season_name,
             disp_subgroup_name,
             disp_season_num,
-            conf_episode_offset,
+            conf_tmdb_episode_offset,
             conf_language,
             conf_codec,
-            conf_season_num
-        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
+            conf_season_num,
+            conf_bangumi_episode_offset
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)",
         &[
             &season.mikan_subject_id.to_string(),
             &season.mikan_subgroup_id.to_string(),
@@ -142,10 +146,11 @@ pub fn create_season(season: &AnimeSeason) {
             &season.disp_season_name,
             &season.disp_subgroup_name,
             &season.disp_season_num.to_string(),
-            &season.conf_episode_offset.to_string(),
+            &season.conf_tmdb_episode_offset.to_string(),
             &season.conf_language,
             &season.conf_codec,
             &season.conf_season_num.to_string(),
+            &season.conf_bangumi_episode_offset.to_string(),
         ],
     ).unwrap();
 }
@@ -181,10 +186,11 @@ pub fn read_seasons() -> Vec<AnimeSeason> {
             disp_season_name: row.get(14)?,
             disp_subgroup_name: row.get(15)?,
             disp_season_num: row.get(16)?,
-            conf_episode_offset: row.get(17)?,
+            conf_tmdb_episode_offset: row.get(17)?,
             conf_language: row.get(18)?,
             conf_codec: row.get(19)?,
             conf_season_num: row.get(20)?,
+            conf_bangumi_episode_offset: row.get(21)?,
         })
     }).unwrap();
 
@@ -196,9 +202,9 @@ pub fn read_seasons() -> Vec<AnimeSeason> {
     seasons
 }
 
-pub fn get_season_episode_offset(mikan_subject_id: i32, mikan_subgroup_id: i32) -> i32 {
+pub fn get_season_tmdb_episode_offset(mikan_subject_id: i32, mikan_subgroup_id: i32) -> i32 {
     let conn = get_connection().unwrap();
-    let mut stmt = conn.prepare("select conf_episode_offset from library_anime_season where mikan_subject_id = ?1 and mikan_subgroup_id = ?2").unwrap();
+    let mut stmt = conn.prepare("select conf_tmdb_episode_offset from library_anime_season where mikan_subject_id = ?1 and mikan_subgroup_id = ?2").unwrap();
     let offset_iter = stmt.query_map(&[&mikan_subject_id, &mikan_subgroup_id], |row| {
         Ok(row.get(0)?)
     }).unwrap();
@@ -210,10 +216,36 @@ pub fn get_season_episode_offset(mikan_subject_id: i32, mikan_subgroup_id: i32) 
     0
 }
 
-pub fn set_season_episode_offset(mikan_subject_id: i32, mikan_subgroup_id: i32, new_offset: i32) {
+pub fn set_season_tmdb_episode_offset(mikan_subject_id: i32, mikan_subgroup_id: i32, new_offset: i32) {
     let conn = get_connection().unwrap();
     conn.execute(
-        "update library_anime_season set conf_episode_offset = ?1 where mikan_subject_id = ?2 and mikan_subgroup_id = ?3",
+        "update library_anime_season set conf_tmdb_episode_offset = ?1 where mikan_subject_id = ?2 and mikan_subgroup_id = ?3",
+        &[&new_offset, &mikan_subject_id, &mikan_subgroup_id],
+    ).unwrap();
+    conn.execute(
+        "update library_anime_season_item set disp_episode_num = mikan_parsed_episode_num + ?1 where mikan_subject_id = ?2 and mikan_subgroup_id = ?3",
+        &[&new_offset, &mikan_subject_id, &mikan_subgroup_id],
+    ).unwrap();
+}
+
+pub fn get_season_bangumi_episode_offset(mikan_subject_id: i32, mikan_subgroup_id: i32) -> i32 {
+    let conn = get_connection().unwrap();
+    let mut stmt = conn.prepare("select conf_bangumi_episode_offset from library_anime_season where mikan_subject_id = ?1 and mikan_subgroup_id = ?2").unwrap();
+    let offset_iter = stmt.query_map(&[&mikan_subject_id, &mikan_subgroup_id], |row| {
+        Ok(row.get(0)?)
+    }).unwrap();
+
+    for offset in offset_iter {
+        return offset.unwrap();
+    }
+
+    0
+}
+
+pub fn set_season_bangumi_episode_offset(mikan_subject_id: i32, mikan_subgroup_id: i32, new_offset: i32) {
+    let conn = get_connection().unwrap();
+    conn.execute(
+        "update library_anime_season set conf_bangumi_episode_offset = ?1 where mikan_subject_id = ?2 and mikan_subgroup_id = ?3",
         &[&new_offset, &mikan_subject_id, &mikan_subgroup_id],
     ).unwrap();
     conn.execute(
@@ -306,7 +338,7 @@ pub fn init_cache_library_anime_season_item_table(conn: &Connection) -> Result<(
 pub fn create_item(item: &crate::module::database::cache::rss::MikanItem) {
     let conn = get_connection().unwrap();
     let season = read_season_info(item.mikan_subject_id, item.mikan_subgroup_id).unwrap();
-    let episode_num_offseted = item.mikan_parsed_episode_num + season.conf_episode_offset;
+    let disp_episode_num_offseted = item.mikan_parsed_episode_num + season.conf_tmdb_episode_offset;
 
     conn.execute(
         "insert or replace into library_anime_season_item (
@@ -344,7 +376,7 @@ pub fn create_item(item: &crate::module::database::cache::rss::MikanItem) {
             &item.mikan_parsed_episode_num.to_string(),
             &item.mikan_parsed_language,
             &item.mikan_parsed_codec,
-            &episode_num_offseted.to_string(),
+            &disp_episode_num_offseted.to_string(),
             &item.bangumi_parsed_episode_id.to_string(),
             &item.bangumi_parsed_episode_ep.to_string(),
             &item.bangumi_parsed_episode_sort.to_string(),

--- a/crates/bangumi007/src/module/database/library.rs
+++ b/crates/bangumi007/src/module/database/library.rs
@@ -248,10 +248,6 @@ pub fn set_season_bangumi_episode_offset(mikan_subject_id: i32, mikan_subgroup_i
         "update library_anime_season set conf_bangumi_episode_offset = ?1 where mikan_subject_id = ?2 and mikan_subgroup_id = ?3",
         &[&new_offset, &mikan_subject_id, &mikan_subgroup_id],
     ).unwrap();
-    conn.execute(
-        "update library_anime_season_item set disp_episode_num = mikan_parsed_episode_num + ?1 where mikan_subject_id = ?2 and mikan_subgroup_id = ?3",
-        &[&new_offset, &mikan_subject_id, &mikan_subgroup_id],
-    ).unwrap();
 }
 
 pub fn get_season_conf_season_num(mikan_subject_id: i32, mikan_subgroup_id: i32) -> i32 {
@@ -304,7 +300,7 @@ pub struct AnimeSeasonItem {
     pub disp_episode_num: i32,
     pub bangumi_parsed_episode_id: i32,
     pub bangumi_parsed_episode_ep: i32,
-    pub bangumi_parsed_episode_sort: i32,
+    pub bangumi_parsed_episode_sort: String,
 }
 
 #[deny(dead_code)]
@@ -328,8 +324,9 @@ pub fn init_cache_library_anime_season_item_table(conn: &Connection) -> Result<(
             disp_episode_num integer,
             bangumi_parsed_episode_id integer,
             bangumi_parsed_episode_ep integer,
-            bangumi_parsed_episode_sort integer
+            bangumi_parsed_episode_sort text
         )",
+        // TODO: bangumi_parsed_episode_id, bangumi_parsed_episode_ep, bangumi_parsed_episode_sort deprecated
         [],
     )?;
     Ok(())

--- a/crates/bangumi007/src/module/library/media_library.rs
+++ b/crates/bangumi007/src/module/library/media_library.rs
@@ -130,7 +130,7 @@ pub fn update_season_config(season: &AnimeSeason, delete_items: bool, fetch_item
     let conn = get_connection().unwrap();
 
     conn.execute(
-        "update library_anime_season set conf_tmdb_episode_offset = ?1, conf_language = ?2, conf_codec = ?3, conf_bangumi_episode_offset = ?4, where mikan_subject_id = ?5 and mikan_subgroup_id = ?6",
+        "update library_anime_season set conf_tmdb_episode_offset = ?1, conf_language = ?2, conf_codec = ?3, conf_bangumi_episode_offset = ?4 where mikan_subject_id = ?5 and mikan_subgroup_id = ?6",
         &[
             &season.conf_tmdb_episode_offset.to_string(),
             &season.conf_language,
@@ -170,7 +170,7 @@ pub fn update_season_config(season: &AnimeSeason, delete_items: bool, fetch_item
     // fetch items from the rss feed
     // TODO: fetch with updated config
     if fetch_items {
-        let url = format!("https://mikanani.me/RSS/Bangumi?bangumiId={}&subgroupid={}", season.mikan_subject_id, season.mikan_subgroup_id);
+        let url = format!("https://mikanime.tv/RSS/Bangumi?bangumiId={}&subgroupid={}", season.mikan_subject_id, season.mikan_subgroup_id);
         let items = mikan_parser::update_rss(&url).unwrap();
         let items = mikan_parser::expand_history_episodes(items);
         update_library(&items);

--- a/crates/bangumi007/src/module/library/media_library.rs
+++ b/crates/bangumi007/src/module/library/media_library.rs
@@ -66,10 +66,11 @@ pub fn update_library(items: &Vec<rss::MikanItem>) {
                         disp_season_name,
                         disp_subgroup_name,
                         disp_season_num,
-                        conf_episode_offset: 0,
+                        conf_tmdb_episode_offset: 0,
                         conf_language: "".to_string(),
                         conf_codec: "".to_string(),
                         conf_season_num: -1,
+                        conf_bangumi_episode_offset: 0,
                     };
                     create_season(&season);
                     create_item(&item);
@@ -129,11 +130,12 @@ pub fn update_season_config(season: &AnimeSeason, delete_items: bool, fetch_item
     let conn = get_connection().unwrap();
 
     conn.execute(
-        "update library_anime_season set conf_episode_offset = ?1, conf_language = ?2, conf_codec = ?3 where mikan_subject_id = ?4 and mikan_subgroup_id = ?5",
+        "update library_anime_season set conf_tmdb_episode_offset = ?1, conf_language = ?2, conf_codec = ?3, conf_bangumi_episode_offset = ?4, where mikan_subject_id = ?5 and mikan_subgroup_id = ?6",
         &[
-            &season.conf_episode_offset.to_string(),
+            &season.conf_tmdb_episode_offset.to_string(),
             &season.conf_language,
             &season.conf_codec,
+            &season.conf_bangumi_episode_offset.to_string(),
             &season.mikan_subject_id.to_string(),
             &season.mikan_subgroup_id.to_string(),
         ],
@@ -155,11 +157,11 @@ pub fn update_season_config(season: &AnimeSeason, delete_items: bool, fetch_item
     // for items in library_anime_season_item, 
     // where mikan_subject_id = season.mikan_subject_id 
     // and mikan_subgroup_id = season.mikan_subgroup_id,
-    // update disp_episode_num = mikan_parsed_episode_num + conf_episode_offset
+    // update disp_episode_num = mikan_parsed_episode_num + conf_tmdb_episode_offset
     conn.execute(
         "update library_anime_season_item set disp_episode_num = mikan_parsed_episode_num + ?1 where mikan_subject_id = ?2 and mikan_subgroup_id = ?3",
         &[
-            &season.conf_episode_offset.to_string(),
+            &season.conf_tmdb_episode_offset.to_string(),
             &season.mikan_subject_id.to_string(),
             &season.mikan_subgroup_id.to_string(),
         ],

--- a/crates/bangumi007/src/module/mod.rs
+++ b/crates/bangumi007/src/module/mod.rs
@@ -6,3 +6,4 @@ pub mod library;
 pub mod core;
 pub mod database;
 pub mod utils;
+mod scrobbler;

--- a/crates/bangumi007/src/module/mod.rs
+++ b/crates/bangumi007/src/module/mod.rs
@@ -6,4 +6,4 @@ pub mod library;
 pub mod core;
 pub mod database;
 pub mod utils;
-mod scrobbler;
+pub mod scrobbler;

--- a/crates/bangumi007/src/module/parser/bangumi_parser.rs
+++ b/crates/bangumi007/src/module/parser/bangumi_parser.rs
@@ -236,7 +236,7 @@ pub fn get_bangumi_episodes(bangumi_subject_id: i32) -> Result<Vec<BangumiEpisod
         return Ok(cache_result);
     }
     
-    let url = format!("https://api.bgm.tv/v0/episodes?subject_id={}&limit={}", bangumi_subject_id, 200);
+    let url = format!("https://api.bgm.tv/v0/episodes?subject_id={}", bangumi_subject_id);
     // add user-agent
     let client = reqwest::blocking::Client::builder()
         .user_agent("MapleWithered/Bangumi007 (https://github.com/MapleWithered/Bangumi007)")

--- a/crates/bangumi007/src/module/parser/bangumi_parser.rs
+++ b/crates/bangumi007/src/module/parser/bangumi_parser.rs
@@ -308,8 +308,8 @@ pub fn get_bangumi_episodes(bangumi_subject_id: i32) -> Result<Vec<BangumiEpisod
         let episode_sort = episode
             .get("sort")
             .ok_or_else(|| new_warn("Failed to get episode sort"))
-            .and_then(|x| x.as_i64().ok_or_else(|| new_warn("Failed to get episode sort as i64")))
-            .and_then(|x| x.try_into().map_err(|_| new_warn("Failed to convert episode sort to i32")));
+            .and_then(|x| x.as_str().ok_or_else(|| new_warn("Failed to get episode sort as str")))
+            .and_then(|x| Ok(x.to_string()));
         let episode_sort = match episode_sort {
             Ok(episode_sort) => episode_sort,
             Err(_) => continue,
@@ -367,15 +367,15 @@ pub fn get_bangumi_episodes(bangumi_subject_id: i32) -> Result<Vec<BangumiEpisod
 }
 
 pub fn parse_bangumi_episode(bangumi_subject_id: i32, mikan_episode_num: i32, episode_type: i32) -> Result<BangumiEpisode, Box<dyn Error>> {
-    let episodes = get_bangumi_episodes(bangumi_subject_id)?;
-    let episode = episodes.iter().find(|x| x.episode_sort == mikan_episode_num && x.episode_type == episode_type);
-    if episode.is_some() {
-        return Ok(episode.unwrap().clone());
-    }
-    let episode = episodes.iter().find(|x| x.episode_ep == mikan_episode_num && x.episode_type == episode_type);
-    if episode.is_some() {
-        return Ok(episode.unwrap().clone());
-    }
+    // let episodes = get_bangumi_episodes(bangumi_subject_id)?;
+    // let episode = episodes.iter().find(|x| x.episode_sort == mikan_episode_num && x.episode_type == episode_type);
+    // if episode.is_some() {
+    //     return Ok(episode.unwrap().clone());
+    // }
+    // let episode = episodes.iter().find(|x| x.episode_ep == mikan_episode_num && x.episode_type == episode_type);
+    // if episode.is_some() {
+    //     return Ok(episode.unwrap().clone());
+    // }
     Err(new_err("Failed to find episode"))
 }
 

--- a/crates/bangumi007/src/module/parser/bangumi_parser.rs
+++ b/crates/bangumi007/src/module/parser/bangumi_parser.rs
@@ -308,7 +308,7 @@ pub fn get_bangumi_episodes(bangumi_subject_id: i32) -> Result<Vec<BangumiEpisod
         let episode_sort = episode
             .get("sort")
             .ok_or_else(|| new_warn("Failed to get episode sort"))
-            .and_then(|x| x.as_str().ok_or_else(|| new_warn("Failed to get episode sort as str")))
+            .and_then(|x| x.as_i64().ok_or_else(|| new_warn(&*format!("Failed to get episode sort as str: {:?}", x))))
             .and_then(|x| Ok(x.to_string()));
         let episode_sort = match episode_sort {
             Ok(episode_sort) => episode_sort,

--- a/crates/bangumi007/src/module/parser/mikan_parser.rs
+++ b/crates/bangumi007/src/module/parser/mikan_parser.rs
@@ -199,7 +199,7 @@ pub fn update_rss(url: &str) -> Result<Vec<MikanItem>, Box<dyn Error>> {
             mikan_parsed_codec: parse_filename_to_codec(&title),                 // Codec
             bangumi_parsed_episode_id: -1,
             bangumi_parsed_episode_ep: -1,
-            bangumi_parsed_episode_sort: -1,
+            bangumi_parsed_episode_sort: "".to_string(),
         });
     }
 
@@ -465,23 +465,23 @@ fn fill_episode_information(item: &MikanItem) -> Result<MikanItem, Box<dyn Error
         None => 0
     };
 
-    let bangumi_episode_info = match &mikan_subject_info {
-        Some(info) => {
-            let episode_info = parse_bangumi_episode(info.bangumi_subject_id,
-                                                     item.mikan_parsed_episode_num + episode_offset,
-                                                     0);
-            match episode_info {
-                Ok(info) => Some(info),
-                Err(_) => None
-            }
-        }
-        None => None
-    };
+    // let bangumi_episode_info = match &mikan_subject_info {
+    //     Some(info) => {
+    //         let episode_info = parse_bangumi_episode(info.bangumi_subject_id,
+    //                                                  item.mikan_parsed_episode_num + episode_offset,
+    //                                                  0);
+    //         match episode_info {
+    //             Ok(info) => Some(info),
+    //             Err(_) => None
+    //         }
+    //     }
+    //     None => None
+    // };
 
-    let (bangumi_parsed_episode_id, bangumi_parsed_episode_ep, bangumi_parsed_episode_sort) = match &bangumi_episode_info {
-        Some(info) => (info.episode_id, info.episode_ep, info.episode_sort),
-        None => (-1, -1, -1)
-    };
+    // let (bangumi_parsed_episode_id, bangumi_parsed_episode_ep, bangumi_parsed_episode_sort) = match &bangumi_episode_info {
+    //     Some(info) => (info.episode_id, info.episode_ep, info.episode_sort.clone()),
+    //     None => (-1, -1, "".to_string())
+    // };
 
     Ok(MikanItem {
         mikan_item_uuid: item.mikan_item_uuid.to_string(),
@@ -498,9 +498,9 @@ fn fill_episode_information(item: &MikanItem) -> Result<MikanItem, Box<dyn Error
         mikan_parsed_episode_num: item.mikan_parsed_episode_num + episode_offset,
         mikan_parsed_language: item.mikan_parsed_language.to_string(),
         mikan_parsed_codec: item.mikan_parsed_codec.to_string(),
-        bangumi_parsed_episode_id,
-        bangumi_parsed_episode_ep,
-        bangumi_parsed_episode_sort,
+        bangumi_parsed_episode_id: -1,
+        bangumi_parsed_episode_ep: -1,
+        bangumi_parsed_episode_sort: "".to_string(),
     })
 }
 

--- a/crates/bangumi007/src/module/parser/mikan_parser.rs
+++ b/crates/bangumi007/src/module/parser/mikan_parser.rs
@@ -250,7 +250,7 @@ pub fn update_rss(url: &str) -> Result<Vec<MikanItem>, Box<dyn Error>> {
 pub fn expand_history_episodes(items: Vec<MikanItem>) -> Vec<MikanItem> {
     // Expand the RSS and get history episodes
     // For each item in items, get its bangumi id and subgroup id
-    // Then visit https://mikanani.me/RSS/Bangumi?bangumiId={}&subgroupid={}
+    // Then visit https://mikanime.tv/RSS/Bangumi?bangumiId={}&subgroupid={}
     // Parse the RSS and get all the episodes
     let mut result = Vec::new();
     // HashSet to store visited bgm-sub pairs
@@ -259,7 +259,7 @@ pub fn expand_history_episodes(items: Vec<MikanItem>) -> Vec<MikanItem> {
         if visited.contains(&(item.mikan_subject_id, item.mikan_subgroup_id)) {
             continue;
         }
-        let url = format!("https://mikanani.me/RSS/Bangumi?bangumiId={}&subgroupid={}", item.mikan_subject_id, item.mikan_subgroup_id);
+        let url = format!("https://mikanime.tv/RSS/Bangumi?bangumiId={}&subgroupid={}", item.mikan_subject_id, item.mikan_subgroup_id);
         let items_full = update_rss(&url).unwrap();
         // Add to the result
         for item in items_full {
@@ -289,7 +289,7 @@ pub fn expand_history_episodes(items: Vec<MikanItem>) -> Vec<MikanItem> {
 ///
 fn fill_episode_information(item: &MikanItem) -> Result<MikanItem, Box<dyn Error>> {
     // build url from item's uuid
-    let url = format!("https://mikanani.me/Home/Episode/{}", item.mikan_item_uuid);
+    let url = format!("https://mikanime.tv/Home/Episode/{}", item.mikan_item_uuid);
 
     let response = retry(Fixed::from_millis(5000), || {
         match get(&url) {
@@ -369,7 +369,7 @@ fn fill_episode_information(item: &MikanItem) -> Result<MikanItem, Box<dyn Error
             let start = response[x..].find("url(\'").ok_or_else(|| new_err("Failed to parse image"))?;
             let start = x + start + 5;
             let end = response[start..].find("\'").ok_or_else(|| new_err("Failed to parse image"))?;
-            let url = format!("https://mikanani.me{}", response[start..start + end].to_string()).to_string();
+            let url = format!("https://mikanime.tv{}", response[start..start + end].to_string()).to_string();
             Ok(url)
         })
         .unwrap_or("".to_string());
@@ -513,9 +513,9 @@ fn fill_episode_information(item: &MikanItem) -> Result<MikanItem, Box<dyn Error
 ///
 /// ## Procedure
 ///
-/// e.g. https://mikanani.me/Home/Bangumi/3344
+/// e.g. https://mikanime.tv/Home/Bangumi/3344
 ///
-/// 1. Visit the page https://mikanani.me/Home/Bangumi/3344
+/// 1. Visit the page https://mikanime.tv/Home/Bangumi/3344
 /// 2. Parse the page and get the bangumi id & url https://bgm.tv/subject/444557
 ///
 /// ## Output
@@ -523,7 +523,7 @@ fn fill_episode_information(item: &MikanItem) -> Result<MikanItem, Box<dyn Error
 /// Bangui subject id : `i32`
 pub fn get_bangumi_subject_id(mikan_subject_id: i32) -> rusqlite::Result<i32, Box<dyn Error>> {
     // build url from item's uuid
-    let url = format!("https://mikanani.me/Home/Bangumi/{}", mikan_subject_id);
+    let url = format!("https://mikanime.tv/Home/Bangumi/{}", mikan_subject_id);
 
     let response = retry::retry(Fixed::from_millis(5000), || {
         match get(&url) {
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn test_parse_rss() {
-        let url = "https://mikanani.me/RSS/Bangumi?bangumiId=3305&subgroupid=382";
+        let url = "https://mikanime.tv/RSS/Bangumi?bangumiId=3305&subgroupid=382";
         let items = update_rss(url).unwrap();
         for item in items {
             println!("{:?}", item);

--- a/crates/bangumi007/src/module/scrobbler/bangumi.rs
+++ b/crates/bangumi007/src/module/scrobbler/bangumi.rs
@@ -1,0 +1,189 @@
+use std::error::Error;
+use serde_json::json;
+use crate::module::config::CONFIG;
+use crate::module::parser::bangumi_parser::get_bangumi_episodes;
+use crate::module::utils::error::new_err;
+
+#[derive(Debug)]
+pub enum BangumiEpisodeStatus {
+    NotCollected,
+    WantToWatch,
+    Watched,
+    Dropped,
+}
+
+#[derive(Debug)]
+pub enum BangumiEpisodeType {
+    MainStory,
+    Special,
+    OP,
+    ED,
+    Other,
+}
+
+#[derive(Debug)]
+pub struct BangumiEpisodeCollection {
+    id: i32,
+    sort: i32,
+    ep: i32,
+    airdate: String,
+    name: String,
+    name_cn: String,
+    ep_type: BangumiEpisodeType,
+    status: BangumiEpisodeStatus,
+}
+
+pub fn get_bangumi_episode_collection_status(bangumi_subject_id: i32) -> Result<Vec<BangumiEpisodeCollection>, Box<dyn Error>> {
+    // curl -X 'GET' \
+    //   'https://api.bgm.tv/v0/users/-/collections/{bangumi_subject_id}/episodes' \
+    //   -H 'accept: application/json' \
+    //   -H 'Authorization: Bearer {access_token}'
+
+    let access_token = CONFIG.read().unwrap().scrobbler_config.bangumi_access_token.clone();
+    let url = format!("https://api.bgm.tv/v0/users/-/collections/{}/episodes", bangumi_subject_id);
+    let client = reqwest::blocking::Client::new();
+    let res = retry::retry(retry::delay::Fibonacci::from_millis(1000).take(5), || {
+        client.get(&url)
+            .header("Authorization", format!("Bearer {}", access_token))
+            .header("accept", "application/json")
+            // UA is forced
+            .header("User-Agent", "MapleWithered/Bangumi007 (https://github.com/MapleWithered/Bangumi007)")
+            .send()
+            .map_err(|e| new_err(&format!("Failed to send request: {}", e)))
+    }).map_err(|e| new_err(&format!("Failed to send request: {}", e)))?;
+
+    if !res.status().is_success() {
+        return Err(new_err(&format!("Failed to get bangumi episode collection status: {}", res.text()?)));
+    }
+
+    // parse json as object
+    let json: serde_json::Value = res
+        .json()
+        .map_err(|e| new_err(&format!("Failed to parse json: {}", e)))?;
+    let mut result = Vec::new();
+
+    let data = json.as_object()
+        .and_then(|o| o.get("data"))
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| new_err("Failed to parse json"))?;
+
+    for item in data {
+        let item = item.as_object().ok_or_else(|| new_err("Failed to parse json"))?;
+        let episode = item.get("episode")
+            .and_then(|e| e.as_object())
+            .ok_or_else(|| new_err("Failed to parse episode"))?;
+        let status = item.get("type")
+            .and_then(|t| t.as_i64())
+            .ok_or_else(|| new_err("Failed to parse type"))?;
+
+        result.push(BangumiEpisodeCollection {
+            id: episode.get("id")
+                .and_then(|i| i.as_i64())
+                .ok_or_else(|| new_err("Failed to parse id"))? as i32,
+            sort: episode.get("sort")
+                .and_then(|s| s.as_i64())
+                .ok_or_else(|| new_err("Failed to parse sort"))? as i32,
+            ep: episode.get("ep")
+                .and_then(|e| e.as_i64())
+                .ok_or_else(|| new_err("Failed to parse ep"))? as i32,
+            airdate: episode.get("airdate")
+                .and_then(|a| a.as_str())
+                .unwrap_or("").to_string(),
+            name: episode.get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("").to_string(),
+            name_cn: episode.get("name_cn")
+                .and_then(|n| n.as_str())
+                .unwrap_or("").to_string(),
+            ep_type: match episode.get("type")
+                .and_then(|t| t.as_i64())
+                .ok_or_else(|| new_err("Failed to parse type"))? as i32 {
+                0 => BangumiEpisodeType::MainStory,
+                1 => BangumiEpisodeType::Special,
+                2 => BangumiEpisodeType::OP,
+                3 => BangumiEpisodeType::ED,
+                _ => BangumiEpisodeType::Other,
+            },
+            status: match status {
+                0 => BangumiEpisodeStatus::NotCollected,
+                1 => BangumiEpisodeStatus::WantToWatch,
+                2 => BangumiEpisodeStatus::Watched,
+                3 => BangumiEpisodeStatus::Dropped,
+                _ => BangumiEpisodeStatus::NotCollected,
+            },
+        });
+    }
+
+    Ok(result)
+}
+
+pub fn update_bangumi_episode_status(bangumi_subject_id: i32, bangumi_episode_sort: i32, status: BangumiEpisodeStatus) -> Result<(), Box<dyn Error>> {
+    // First, get all the episode ids of the bangumi subject
+    let episodes = get_bangumi_episodes(bangumi_subject_id)
+        .map_err(|e| new_err(&format!("Failed to get bangumi episodes: {}", e)))?;
+
+    // Then, match with the episode number
+    // find episode_type=0 and episode_sort=bangumi_episode_num
+    let episode_id = episodes.iter().find(|e| e.episode_type == 0 && e.episode_sort == bangumi_episode_sort)
+        .ok_or_else(|| new_err("Failed to find the episode"))?;
+    let episode_id = (*episode_id).episode_id;
+
+    // Finally, update the status of the episode
+    // curl -X 'PATCH' \
+    //   'https://api.bgm.tv/v0/users/-/collections/{subject_id}/episodes' \
+    //   -H 'accept: */*' \
+    //   -H 'Authorization: Bearer {access_token}' \
+    //   -H 'Content-Type: application/json' \
+    //   -d '{
+    //   "episode_id": [
+    //     {episode_id}
+    //   ],
+    //   "type": 2
+    // }'
+    let access_token = CONFIG.read().unwrap().scrobbler_config.bangumi_access_token.clone();
+    let url = format!("https://api.bgm.tv/v0/users/-/collections/{}/episodes", bangumi_subject_id);
+    let client = reqwest::blocking::Client::new();
+    let res = retry::retry(retry::delay::Fibonacci::from_millis(1000).take(5), || {
+        client.patch(&url)
+            .header("Authorization", format!("Bearer {}", access_token))
+            .header("Content-Type", "application/json")
+            // UA is forced
+            .header("User-Agent", "MapleWithered/Bangumi007 (https://github.com/MapleWithered/Bangumi007)")
+            .json(&json!({
+            "episode_id": [episode_id],
+            "type": match status {
+                BangumiEpisodeStatus::NotCollected => 0,
+                BangumiEpisodeStatus::WantToWatch => 1,
+                BangumiEpisodeStatus::Watched => 2,
+                BangumiEpisodeStatus::Dropped => 3,
+            }
+        }))
+            .send()
+            .map_err(|e| new_err(&format!("Failed to send request: {}", e)))
+    }).map_err(|e| new_err(&format!("Failed to send request: {}", e)))?;
+
+    if !res.status().is_success() {
+        return Err(new_err(&format!("Failed to update bangumi episode status: {}", res.text()?)));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::module::logger;
+    use super::*;
+
+    #[test]
+    fn test_get_bangumi_episode_collection_status() {
+        logger::init();
+        let result = get_bangumi_episode_collection_status(425909).unwrap();
+        println!("{:?}", result);
+    }
+
+    #[test]
+    fn test_update_bangumi_episode_status() {
+        logger::init();
+        update_bangumi_episode_status(425909, 7, BangumiEpisodeStatus::Watched).unwrap();
+    }
+}

--- a/crates/bangumi007/src/module/scrobbler/bangumi.rs
+++ b/crates/bangumi007/src/module/scrobbler/bangumi.rs
@@ -211,6 +211,6 @@ mod tests {
     #[test]
     fn test_update_bangumi_episode_status() {
         logger::init();
-        update_bangumi_episode_status(425909, 7, BangumiEpisodeStatus::Watched).unwrap();
+        update_bangumi_episode_status(425909, "7".to_string(), BangumiEpisodeStatus::Watched).unwrap();
     }
 }

--- a/crates/bangumi007/src/module/scrobbler/bangumi.rs
+++ b/crates/bangumi007/src/module/scrobbler/bangumi.rs
@@ -195,6 +195,11 @@ pub fn update_bangumi_episode_status(bangumi_subject_id: i32, bangumi_episode_so
     Ok(())
 }
 
+pub fn update_bangumi_episode_status_send(bangumi_subject_id: i32, bangumi_episode_sort: String, status: BangumiEpisodeStatus) -> bool {
+    let res = update_bangumi_episode_status(bangumi_subject_id, bangumi_episode_sort, status);
+    return res.is_err();
+}
+
 #[cfg(test)]
 mod tests {
     use crate::module::logger;

--- a/crates/bangumi007/src/module/scrobbler/mod.rs
+++ b/crates/bangumi007/src/module/scrobbler/mod.rs
@@ -1,0 +1,1 @@
+pub mod bangumi;

--- a/crates/bangumi007/src/ui/apps/libraryapp.rs
+++ b/crates/bangumi007/src/ui/apps/libraryapp.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::{Arc, RwLock};
+use lazy_static::lazy_static;
 
 use eframe::egui;
 use eframe::egui::{RichText, vec2};
@@ -17,6 +18,10 @@ pub struct LibraryApp {
     pub library: Arc<RwLock<Vec<AppAnimeSeries>>>,
 }
 
+lazy_static!(
+    // flag for bangumi status update
+    pub static ref BANGUMI_STATUS_UPDATE: Arc<RwLock<bool>> = Arc::new(RwLock::new(false));
+);
 
 impl LibraryApp {
     fn series_layout(&mut self, ui: &mut egui::Ui, series: &AppAnimeSeries, season_conf_dialog_window: Rc<RefCell<SeasonConfDialogWindow>>) {

--- a/crates/bangumi007/src/ui/apps/libraryapp.rs
+++ b/crates/bangumi007/src/ui/apps/libraryapp.rs
@@ -49,7 +49,7 @@ impl LibraryApp {
                                 disp_season_name = format!("第 {} 季 - {}", season.disp_season_num,
                                                            season.disp_season_name);
                             }
-                            if season.conf_episode_offset != 0 {
+                            if season.conf_tmdb_episode_offset != 0 {
                                 disp_season_name = format!("* {}", disp_season_name);
                             }
                             disp_season_name
@@ -146,7 +146,8 @@ pub struct AppAnimeSeason {
     pub disp_thumbnail_url: String,
     pub default_season_num: i32,
     pub conf_season_num: i32,
-    pub conf_episode_offset: i32,
+    pub conf_tmdb_episode_offset: i32,
+    pub conf_bangumi_episode_offset: i32,
     pub episodes: Vec<AppAnimeEpisode>,
 }
 
@@ -171,7 +172,8 @@ impl From<AnimeSeason> for AppAnimeSeason {
                 season.bangumi_season_num
             },
             episodes: vec![],
-            conf_episode_offset: season.conf_episode_offset,
+            conf_tmdb_episode_offset: season.conf_tmdb_episode_offset,
+            conf_bangumi_episode_offset: season.conf_bangumi_episode_offset,
             conf_season_num: season.conf_season_num,
         }
     }

--- a/crates/bangumi007/src/ui/apps/season_conf_dialog_window.rs
+++ b/crates/bangumi007/src/ui/apps/season_conf_dialog_window.rs
@@ -21,6 +21,7 @@ pub struct SeasonConfDialogWindow {
     pub ep_num_min: i32,
     pub ep_num_max: i32,
     pub conf_tmdb_ep_offset: i32,
+    pub conf_bangumi_ep_offset: i32,
 }
 
 impl SeasonConfDialogWindow {
@@ -37,6 +38,7 @@ impl SeasonConfDialogWindow {
             ep_num_min: -1,
             ep_num_max: -1,
             conf_tmdb_ep_offset: 0,
+            conf_bangumi_ep_offset: 0,
         }
     }
 
@@ -59,6 +61,7 @@ impl SeasonConfDialogWindow {
                         };
 
                         self.conf_tmdb_ep_offset = season.conf_tmdb_episode_offset;
+                        self.conf_bangumi_ep_offset = season.conf_bangumi_episode_offset;
                         self.ep_num_min = season.episodes.iter().map(|e| e.disp_episode_num - self.conf_tmdb_ep_offset).min().unwrap();
                         self.ep_num_max = season.episodes.iter().map(|e| e.disp_episode_num - self.conf_tmdb_ep_offset).max().unwrap();
                         break 'outer;
@@ -74,10 +77,10 @@ impl SeasonConfDialogWindow {
             egui::Window::new(RichText::new("编辑季度信息").size(17.))
                 .resizable(false)
                 .title_bar(true)
-                .current_pos([ctx.available_rect().center().x - 120., ctx.available_rect().center().y - 100.])
+                .current_pos([ctx.available_rect().center().x - 120., ctx.available_rect().center().y - 125.])
         }
             .default_width(240.)
-            .default_height(200.)
+            .default_height(250.)
             .open(&mut *self.open.borrow_mut())
             .show(ctx, |ui| {
                 egui::Grid::new("season_conf_dialog")
@@ -109,20 +112,20 @@ impl SeasonConfDialogWindow {
                             );
                         });
                         ui.end_row();
-                        ui.label("原始剧集范围：");
+                        ui.label("字幕组剧集范围：");
                         ui.label(format!("{} - {}", self.ep_num_min, self.ep_num_max));
                         ui.end_row();
-                        ui.label("剧集偏移：");
+                        ui.label("TMDB剧集偏移：").on_hover_text("TMDB剧集偏移量，影响刮削结果文件名与Jellyfin剧集元数据显示");
                         ui.horizontal_centered(|ui| {
                             let drag = ui.add(
                                 egui::DragValue::new(&mut self.conf_tmdb_ep_offset)
                                     .speed(0.3)
                                     .clamp_range(-self.ep_num_min + 1..=999)
-                            );
+                            ).on_hover_text("TMDB剧集偏移量，影响刮削结果文件名与Jellyfin剧集元数据显示");
                             ui.add_enabled_ui(
                                 self.conf_tmdb_ep_offset != 0,
                                 |ui| {
-                                    let button = ui.button("x").on_hover_text("重置剧集偏移");
+                                    let button = ui.button("x").on_hover_text("重置TMDB剧集偏移");
                                     if button.clicked() {
                                         self.conf_tmdb_ep_offset = 0;
                                     }
@@ -130,9 +133,34 @@ impl SeasonConfDialogWindow {
                             );
                         });
                         ui.end_row();
-                        ui.label("新剧集范围：");
+                        ui.label("TMDB剧集范围：");
                         // if self.conf_ep_offset != 0 {
                             ui.label(format!("{} - {}", self.ep_num_min + self.conf_tmdb_ep_offset, self.ep_num_max + self.conf_tmdb_ep_offset));
+                        // } else {
+                        //     ui.label("(未更改)");
+                        // }
+                        ui.end_row();
+                        ui.label("Bgm剧集偏移：").on_hover_text("Bangumi剧集偏移量，影响播放进度同步时的剧集匹配结果");
+                        ui.horizontal_centered(|ui| {
+                            let drag = ui.add(
+                                egui::DragValue::new(&mut self.conf_bangumi_ep_offset)
+                                    .speed(0.3)
+                                    .clamp_range(-self.ep_num_min + 0..=999)
+                            ).on_hover_text("Bangumi剧集偏移量，影响播放进度同步时的剧集匹配结果");
+                            ui.add_enabled_ui(
+                                self.conf_bangumi_ep_offset != 0,
+                                |ui| {
+                                    let button = ui.button("x").on_hover_text("重置Bangumi剧集偏移");
+                                    if button.clicked() {
+                                        self.conf_bangumi_ep_offset = 0;
+                                    }
+                                },
+                            );
+                        });
+                        ui.end_row();
+                        ui.label("Bgm剧集范围：");
+                        // if self.conf_ep_offset != 0 {
+                        ui.label(format!("{} - {}", self.ep_num_min + self.conf_bangumi_ep_offset, self.ep_num_max + self.conf_bangumi_ep_offset));
                         // } else {
                         //     ui.label("(未更改)");
                         // }
@@ -162,7 +190,8 @@ impl SeasonConfDialogWindow {
                                 conf_season_changed: self.conf_season_changed,
                                 ep_num_min: self.ep_num_min,
                                 ep_num_max: self.ep_num_max,
-                                conf_ep_offset: self.conf_tmdb_ep_offset,
+                                conf_tmdb_ep_offset: self.conf_tmdb_ep_offset,
+                                conf_bangumi_ep_offset: self.conf_bangumi_ep_offset,
                             },
                                         library.clone());
                             self.open_my = false;

--- a/crates/bangumi007/src/ui/apps/season_conf_dialog_window.rs
+++ b/crates/bangumi007/src/ui/apps/season_conf_dialog_window.rs
@@ -20,7 +20,7 @@ pub struct SeasonConfDialogWindow {
     pub conf_season_changed: bool,
     pub ep_num_min: i32,
     pub ep_num_max: i32,
-    pub conf_ep_offset: i32,
+    pub conf_tmdb_ep_offset: i32,
 }
 
 impl SeasonConfDialogWindow {
@@ -36,7 +36,7 @@ impl SeasonConfDialogWindow {
             conf_season_changed: false,
             ep_num_min: -1,
             ep_num_max: -1,
-            conf_ep_offset: 0,
+            conf_tmdb_ep_offset: 0,
         }
     }
 
@@ -58,9 +58,9 @@ impl SeasonConfDialogWindow {
                             season.disp_season_num
                         };
 
-                        self.conf_ep_offset = season.conf_episode_offset;
-                        self.ep_num_min = season.episodes.iter().map(|e| e.disp_episode_num - self.conf_ep_offset).min().unwrap();
-                        self.ep_num_max = season.episodes.iter().map(|e| e.disp_episode_num - self.conf_ep_offset).max().unwrap();
+                        self.conf_tmdb_ep_offset = season.conf_tmdb_episode_offset;
+                        self.ep_num_min = season.episodes.iter().map(|e| e.disp_episode_num - self.conf_tmdb_ep_offset).min().unwrap();
+                        self.ep_num_max = season.episodes.iter().map(|e| e.disp_episode_num - self.conf_tmdb_ep_offset).max().unwrap();
                         break 'outer;
                     }
                 }
@@ -115,16 +115,16 @@ impl SeasonConfDialogWindow {
                         ui.label("剧集偏移：");
                         ui.horizontal_centered(|ui| {
                             let drag = ui.add(
-                                egui::DragValue::new(&mut self.conf_ep_offset)
+                                egui::DragValue::new(&mut self.conf_tmdb_ep_offset)
                                     .speed(0.3)
                                     .clamp_range(-self.ep_num_min + 1..=999)
                             );
                             ui.add_enabled_ui(
-                                self.conf_ep_offset != 0,
+                                self.conf_tmdb_ep_offset != 0,
                                 |ui| {
                                     let button = ui.button("x").on_hover_text("重置剧集偏移");
                                     if button.clicked() {
-                                        self.conf_ep_offset = 0;
+                                        self.conf_tmdb_ep_offset = 0;
                                     }
                                 },
                             );
@@ -132,7 +132,7 @@ impl SeasonConfDialogWindow {
                         ui.end_row();
                         ui.label("新剧集范围：");
                         // if self.conf_ep_offset != 0 {
-                            ui.label(format!("{} - {}", self.ep_num_min + self.conf_ep_offset, self.ep_num_max + self.conf_ep_offset));
+                            ui.label(format!("{} - {}", self.ep_num_min + self.conf_tmdb_ep_offset, self.ep_num_max + self.conf_tmdb_ep_offset));
                         // } else {
                         //     ui.label("(未更改)");
                         // }
@@ -162,7 +162,7 @@ impl SeasonConfDialogWindow {
                                 conf_season_changed: self.conf_season_changed,
                                 ep_num_min: self.ep_num_min,
                                 ep_num_max: self.ep_num_max,
-                                conf_ep_offset: self.conf_ep_offset,
+                                conf_ep_offset: self.conf_tmdb_ep_offset,
                             },
                                         library.clone());
                             self.open_my = false;

--- a/crates/bangumi007/src/ui/binding/library.rs
+++ b/crates/bangumi007/src/ui/binding/library.rs
@@ -8,7 +8,7 @@ use crate::module::downloader::qbittorrent::{clean_empty_folders, download_items
 use crate::module::library::{auto_season_config_clean, update_library};
 use crate::module::parser::mikan_parser::{expand_history_episodes, update_rss};
 use crate::module::scrobbler::bangumi::get_bangumi_episode_collection_status;
-use crate::ui::apps::libraryapp::{AppAnimeEpisode, AppAnimeSeason, AppAnimeSeries, LibraryApp};
+use crate::ui::apps::libraryapp::{AppAnimeEpisode, AppAnimeSeason, AppAnimeSeries, BANGUMI_STATUS_UPDATE, LibraryApp};
 
 impl LibraryApp {
     pub fn update_rss(&mut self) {
@@ -249,6 +249,11 @@ impl LibraryApp {
 
         log::debug!("Bangumi status fetched successfully.");
         drop(library);
+
+        let mut flag_handle = BANGUMI_STATUS_UPDATE.write().unwrap();
+        *flag_handle = false;
+        drop(flag_handle);
+
         false
     }
 }

--- a/crates/bangumi007/src/ui/binding/season_conf.rs
+++ b/crates/bangumi007/src/ui/binding/season_conf.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::thread;
-use crate::module::database::library::{AnimeSeason, read_all_items, read_season_items, read_seasons, set_season_conf_season_num, set_season_disp_season_num, set_season_episode_offset};
+use crate::module::database::library::{AnimeSeason, read_all_items, read_season_items, read_seasons, set_season_conf_season_num, set_season_disp_season_num, set_season_tmdb_episode_offset};
 use crate::module::downloader::qbittorrent::{clean_empty_folders, download_items, rename_torrents_files};
 use crate::module::library::{auto_season_config_clean, update_library};
 use crate::module::parser::mikan_parser::{expand_history_episodes, update_rss};
@@ -48,7 +48,7 @@ pub fn update_conf(conf: SeasonConf, library: Arc<RwLock<Vec<AppAnimeSeries>>>) 
         }
         set_season_disp_season_num(conf.subject_id, conf.subgroup_id, conf.conf_season);
 
-        set_season_episode_offset(conf.subject_id, conf.subgroup_id, conf.conf_ep_offset);
+        set_season_tmdb_episode_offset(conf.subject_id, conf.subgroup_id, conf.conf_ep_offset);
 
         *library = Vec::new();
         // Output media library

--- a/crates/bangumi007/src/ui/binding/season_conf.rs
+++ b/crates/bangumi007/src/ui/binding/season_conf.rs
@@ -17,7 +17,8 @@ pub struct SeasonConf {
     pub conf_season_changed: bool,
     pub ep_num_min: i32,
     pub ep_num_max: i32,
-    pub conf_ep_offset: i32,
+    pub conf_tmdb_ep_offset: i32,
+    pub conf_bangumi_ep_offset: i32,
 }
 
 pub fn update_conf(conf: SeasonConf, library: Arc<RwLock<Vec<AppAnimeSeries>>>) {
@@ -48,7 +49,7 @@ pub fn update_conf(conf: SeasonConf, library: Arc<RwLock<Vec<AppAnimeSeries>>>) 
         }
         set_season_disp_season_num(conf.subject_id, conf.subgroup_id, conf.conf_season);
 
-        set_season_tmdb_episode_offset(conf.subject_id, conf.subgroup_id, conf.conf_ep_offset);
+        set_season_tmdb_episode_offset(conf.subject_id, conf.subgroup_id, conf.conf_tmdb_ep_offset);
 
         *library = Vec::new();
         // Output media library

--- a/crates/bangumi007/src/ui/mainapp.rs
+++ b/crates/bangumi007/src/ui/mainapp.rs
@@ -12,9 +12,10 @@ use eframe::egui::{Align, ecolor};
 
 use crate::module::core::init::run_init;
 use crate::ui::mainapp::egui::RichText;
-use crate::ui::apps::libraryapp::LibraryApp;
+use crate::ui::apps::libraryapp::{BANGUMI_STATUS_UPDATE, LibraryApp};
 use crate::ui::apps::logapp::LogApp;
 use crate::ui::apps::panel::Panel;
+use crate::ui::apps::panel::Panel::Library;
 use crate::ui::apps::season_conf_dialog_window::SeasonConfDialogWindow;
 use crate::ui::apps::settingsapp::SettingsApp;
 
@@ -175,5 +176,16 @@ impl eframe::App for MainApp {
             let series = self.library_app.library.clone();
             season_conf_dialog_window.show(ctx, series);
         }
+
+        let flag_handle = BANGUMI_STATUS_UPDATE.read().unwrap();
+        if (*flag_handle) {
+            drop(flag_handle);
+
+            let library_handle = self.library_app.library.clone();
+            LibraryApp::fetch_bangumi_watch_status(library_handle);
+
+        }
+
+
     }
 }

--- a/crates/bangumi007/src/ui/mod.rs
+++ b/crates/bangumi007/src/ui/mod.rs
@@ -1,3 +1,3 @@
 pub mod mainapp;
-mod apps;
-mod binding;
+pub mod apps;
+pub mod binding;

--- a/index.html
+++ b/index.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html class="preload" dir="ltr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover">
+    <link rel="manifest" href="fd4301fdc170fd202474.json">
+    <meta name="format-detection" content="telephone=no">
+    <meta name="msapplication-tap-highlight" content="no">
+    <meta http-equiv="X-UA-Compatibility" content="IE=Edge">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="application-name" content="Jellyfin">
+    <meta name="robots" content="noindex, nofollow, noarchive">
+    <meta name="referrer" content="no-referrer">
+    <meta id="themeColor" name="theme-color" content="#202020">
+    <link rel="apple-touch-icon" sizes="180x180" href="f5bbb798cb2c65908633.png">
+    <link href="6a2e2e6b4186720e5d4f.png"
+          media="screen and (device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="eb8bef4f19b6ad227f46.png"
+          media="screen and (device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="3fa90c593184d5737eb3.png"
+          media="screen and (device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="23a72f5d56f82554aeab.png"
+          media="screen and (device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="d28a57b1e61f9f0dabd9.png"
+          media="screen and (device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="16fc81178d1aee54f6cc.png"
+          media="screen and (device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="f94ebf203ea0c91a47c6.png"
+          media="screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="522fa270807b7b12a9ba.png"
+          media="screen and (device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="0df719b48efcaef953df.png"
+          media="screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="0b37f660ac0f7f01ab41.png"
+          media="screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="d0e56683308a17dba86d.png"
+          media="screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="baafa93a783b76e667ec.png"
+          media="screen and (device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="379bab68d056910336f9.png"
+          media="screen and (device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="d31413d3f03c0873ccbb.png"
+          media="screen and (device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="49d14d0eb7bcdf6f2d1b.png"
+          media="screen and (device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="bbb3e6d43389ba0d436c.png"
+          media="screen and (device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="142d834c201895a46a01.png"
+          media="screen and (device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="e62987a12a58b24f383a.png"
+          media="screen and (device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link href="3f3fe0fd3a0b637b5030.png"
+          media="screen and (device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)"
+          rel="apple-touch-startup-image"/>
+    <link href="a962662957ebbb8eb436.png"
+          media="screen and (device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)"
+          rel="apple-touch-startup-image"/>
+    <link rel="shortcut icon" href="bc8d51405ec040305a87.ico">
+    <meta name="msapplication-TileImage" content="39209dd2362c0db7c673.png">
+    <meta name="msapplication-TileColor" content="#333333">
+    <title>Jellyfin</title>
+    <style>.backgroundContainer-transparent:not(.withBackdrop), .transparentDocument {
+        background: 0 0 !important;
+        background-color: transparent !important
+    }
+
+    .layout-tv .mouseIdle, .layout-tv .mouseIdle a, .layout-tv .mouseIdle button, .layout-tv .mouseIdle input, .layout-tv .mouseIdle label, .layout-tv .mouseIdle select, .layout-tv .mouseIdle textarea, .screensaver-noScroll.mouseIdle, .screensaver-noScroll.mouseIdle a, .screensaver-noScroll.mouseIdle button, .screensaver-noScroll.mouseIdle input, .screensaver-noScroll.mouseIdle label, .screensaver-noScroll.mouseIdle select, .screensaver-noScroll.mouseIdle textarea, .transparentDocument .mouseIdle, .transparentDocument .mouseIdle a, .transparentDocument .mouseIdle button, .transparentDocument .mouseIdle input, .transparentDocument .mouseIdle label, .transparentDocument .mouseIdle select, .transparentDocument .mouseIdle textarea {
+        cursor: none !important
+    }
+
+    .preload {
+        background-color: #101010
+    }
+
+    .hide, .mouseIdle .hide-mouse-idle, .mouseIdle-tv .hide-mouse-idle-tv {
+        display: none !important
+    }
+
+    .mainDrawerHandle {
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        z-index: 1;
+        width: .8em;
+        padding-left: env(safe-area-inset-left);
+        caret-color: transparent
+    }
+
+    [dir=ltr] .mainDrawerHandle {
+        left: 0
+    }
+
+    [dir=rtl] .mainDrawerHandle {
+        left: 0
+    }
+
+    @keyframes fadein {
+        from {
+            opacity: 0
+        }
+        to {
+            opacity: 1
+        }
+    }
+
+    .splashLogo {
+        animation: fadein .5s;
+        width: 30%;
+        height: 30%;
+        background-image: url(assets/img/icon-transparent.png);
+        background-position: center center;
+        background-repeat: no-repeat;
+        background-size: contain;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%)
+    }
+
+    @media screen and (min-device-width: 992px) {
+        .splashLogo {
+            background-image: url(assets/img/banner-light.png)
+        }
+    }</style>
+    <script defer="defer" src="runtime.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.%40babel.runtime.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.%40jellyfin.sdk.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.%40mui.material.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.%40mui.system.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.%40mui.utils.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.lodash-es.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.date-fns.esm.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.%40tanstack.query-core.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.%40tanstack.react-query.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.%40emotion.react.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.core-js.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.axios.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.react-dom.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.jquery.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.webcomponents.js.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.resize-observer-polyfill.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.regenerator-runtime.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.jellyfin-apiclient.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.intersection-observer.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.history.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="node_modules.dompurify.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="99377.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="main.jellyfin.bundle.js?868491527d1ce07a4498"></script>
+    <script defer="defer" src="serviceworker.js?868491527d1ce07a4498"></script>
+    <link href="99377.css?868491527d1ce07a4498" rel="stylesheet">
+    <link href="main.jellyfin.css?868491527d1ce07a4498" rel="stylesheet">
+</head>
+<body dir="ltr">
+<div id="reactRoot">
+    <div class="splashLogo"></div>
+</div>
+<script>
+    // DOM元素.osdTextContainer.startTimeText.osdPositionText有时存在，有时不存在，当存在时，监听其text内容变化
+    // 如有变化，说明视频播放进度发生变化，触发console.log
+    //<div class="osdTextContainer startTimeText osdPositionText" style="margin:0 .25em 0 0">0:47</div>
+    (async function () {
+        // DOM元素.osdTextContainer.startTimeText.osdPositionText有时存在，有时不存在，当存在时，监听其text内容变化
+        // 如有变化，说明视频播放进度发生变化，触发console.log
+        //<div class="osdTextContainer startTimeText osdPositionText" style="margin:0 .25em 0 0">0:47</div>
+
+        var observer = new MutationObserver(function (mutations) {
+            mutations.forEach(function (mutation) {
+                let title = document.querySelector('h3.pageTitle');
+                // take "(series name) - S(/d+)E(/d+) - "
+                let re = /(.*) - S(\d+):E(\d+) - (.*)/;
+                let match = re.exec(title.textContent);
+                if (match) {
+                    console.log(match[1] + ' S' + match[2] + ' E' + match[3] + ' Time:' + mutation.target.textContent);
+                } else {
+                    if (title) {
+                        console.log(title.textContent, mutation.target.textContent);
+                    } else {
+                        console.log(mutation.target.textContent);
+                    }
+                }
+            });
+        });
+
+        while (true) {
+            let targetElement = document.querySelector('.osdTextContainer.startTimeText.osdPositionText');
+            // if not null
+            if (targetElement) {
+                // configuration of the observer:
+                var config = {attributes: true, childList: true, subtree: true};
+                observer.observe(targetElement, config);
+                while (document.querySelector('.osdTextContainer.startTimeText.osdPositionText')) {
+                    await new Promise(r => setTimeout(r, 1000));    // sleep 1s
+                }
+                observer.disconnect();
+            } else {
+                // sleep 1s
+                await new Promise(r => setTimeout(r, 1000));
+            }
+        }
+    })();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -183,26 +183,53 @@
         // 如有变化，说明视频播放进度发生变化，触发console.log
         //<div class="osdTextContainer startTimeText osdPositionText" style="margin:0 .25em 0 0">0:47</div>
 
+        let last_series = '';
+        let last_season = '';
+        let last_episode = '';
+
         var observer = new MutationObserver(function (mutations) {
             mutations.forEach(function (mutation) {
                 let title = document.querySelector('h3.pageTitle');
                 // take "(series name) - S(/d+)E(/d+) - "
                 let re = /(.*) - S(\d+):E(\d+) - (.*)/;
                 let match = re.exec(title.textContent);
-                if (match) {
-                    console.log(match[1] + ' S' + match[2] + ' E' + match[3] + ' Time:' + mutation.target.textContent);
-                } else {
-                    if (title) {
-                        console.log(title.textContent, mutation.target.textContent);
-                    } else {
-                        console.log(mutation.target.textContent);
-                    }
+                if (!match) {
+                    return;
+                }
+                let series = match[1];
+                let season = match[2];
+                let episode = match[3];
+                if (series === last_series && season === last_season && episode === last_episode) {
+                    return;
+                }
+                re = /-(\d+):(\d+)/;
+                match = re.exec(mutation.target.textContent);
+                let minutes = parseInt(match[1]);
+                let seconds = parseInt(match[2]);
+                seconds = minutes * 60 + seconds;
+                if (seconds > 0 && seconds < 90) {
+                    // GET localhost:8007/report?series={}&season={}&episode={}&status=1
+                    // If success, set last_series, last_season, last_episode
+                    let backup_series = last_series;
+                    let backup_season = last_season;
+                    let backup_episode = last_episode;
+                    last_series = series;
+                    last_season = season;
+                    last_episode = episode;
+                    let url = `http://localhost:8007/report?series=${series}&season=${season}&episode=${episode}&status=1`;
+                    fetch(url).then(response => {
+                        if (!response.ok) {
+                            last_series = backup_series;
+                            last_season = backup_season;
+                            last_episode = backup_episode;
+                        }
+                    });
                 }
             });
         });
 
         while (true) {
-            let targetElement = document.querySelector('.osdTextContainer.startTimeText.osdPositionText');
+            let targetElement = document.querySelector('div.osdTextContainer.endTimeText.osdDurationText');
             // if not null
             if (targetElement) {
                 // configuration of the observer:


### PR DESCRIPTION
Jellyfin index.html加入js脚本，检测播放器剩余时间，小于1分30秒时将“剧名 - 季度 - 集数”上报至Bangumi007后端，Bangumi007同步至Bangumi。
判定与上报在Jellyfin WebUI发生，需要Jellyfin用户浏览所在设备可访问Bangumi007后端服务。
需要可修改Jellyfin服务器静态页面。

后续考虑通过Jellyfin插件方式实现Jellyfin媒体服务器判定与上报，代替客户端上报方式。

目前暂未开放动态配置，后续UI细化时加入配置项。